### PR TITLE
Hovering selectable area

### DIFF
--- a/src/_kit/styles/dropdown.html
+++ b/src/_kit/styles/dropdown.html
@@ -58,7 +58,7 @@
       border-radius: 4px;
       box-shadow: 0 0.15em 0.25em rgba(black, 0.25);
       padding: 0.5rem 1rem;
-      top: 150%;
+      top: 100%;
       left: 50%;
       transform: translateX(-50%);
       width: max-content;
@@ -76,8 +76,19 @@
       padding: 0.5rem;
     }
 
+    .dropdown .menu li {
+      margin: 1rem 0;
+    }
+
     .dropdown .menu li:first-of-type {
       margin-top: 0;
+    }
+    li.dropdown {
+      display: inline-block;
+      position: relative;
+      z-index: 1;
+      padding-bottom: 1em;
+      margin-bottom: -1em;
     }
 
     .dropdown:focus-within .menu,


### PR DESCRIPTION
The previous code had a small issue where a portion of the menu was not hoverable while moving the cursor from the parent menu to the submenu. This caused the submenu to start closing when the cursor left the parent selection for the dropdown submenu section. To fix this, I added positive padding and a negative margin to create a selectable area between the parent and submenu. 

- Added padding/margin to create a selectable area
- Moving the submenu up (from 150% to 100%)
- Submenu li decreased the margins