### PR TITLE
Rounded submenu icon

### DIFF
--- a/src/_kit/styles/dropdown.html
+++ b/src/_kit/styles/dropdown.html
@@ -33,7 +33,7 @@
       height: 0.125rem;
       background: var(--bodyTextColor);
       opacity: 1;
-      border-radius: 50%;
+      border-radius: 9999px;
       position: absolute;
       display: block;
       top: 33%;

--- a/src/_kit/styles/dropdown.html
+++ b/src/_kit/styles/dropdown.html
@@ -89,7 +89,7 @@
 
     .dropdown:focus-within > a,
     .dropdown:hover > a {
-      color: var(--primary);
+      color: var(--primaryLight);
     }
 
     .dropdown:focus-within > a:after,
@@ -97,7 +97,7 @@
     .dropdown:hover > a:after,
     .dropdown:hover > a:before {
       top: 52%;
-      background: var(--primary);
+      background: var(--primaryLight);
     }
 
     .dropdown:focus-within > a:before,


### PR DESCRIPTION
Previously the 50% was making the border-radius an elbow shape, not a shape with "rounded corners". Replaced 50% with 9999px which is the "standard" for perfectly round corners.